### PR TITLE
Add instructions to create exo_bespin-specific EC2 launch template to demo notebook

### DIFF
--- a/notebooks/using_aws_ec2.ipynb
+++ b/notebooks/using_aws_ec2.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Using AWS EC2 Instances for `exo_bespin`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The `exo_bespin.aws.aws_tools` module provides functions that enables users to use create, start, stop, and interact with AWS EC2 instances.  The relevant functions are:\n",
     "\n",
     "- `get_config()` - Returns a python dictionary containing the key/value pairs found in the `aws_config.json` file.  This includes the path to the SSH key file, and the `ec2_id`, which points to a specific EC2 instance ID or EC2 launch template ID.\n",
@@ -11,6 +18,56 @@
     "- `stop_ec2(ec2_id, instance)` - Same as above, only for terminating/stopping the given instance instead of creating/starting it.  If an EC2 instance ID is passed with `ec2_id`, the instance is stopped.  However, if an EC2 launch template ID is passed, the instance is terminated.\n",
     "- `transfer_to_ec2(instance, key, client, filename)` - Transfers the file given by `filename` to the given EC2 instance.\n",
     "- `transfer_from_ec2(instance, key, client, filename)` - The same as above, only transfers the given file from the EC2 instance to the local machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating an EC2 Launch Template for `exo-bespin`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Users may create an EC2 launch template through the EC2 console in order to streamline the creation of EC2 instances.  The creation of a launch template only needs to be done once.  Then, one can use the launch template ID to create and interact with EC2 instances through `aws_tools`, and the EC2 instances will automatically come with the appropriate `exo-bespin` software environment.  \n",
+    "\n",
+    "First, users must create a Security Group that will allow a proper SSH connection.  To do this:\n",
+    "\n",
+    "1. Navigate to the AWS EC2 console, click on \"Security Groups\" under \"Network & Security\", and select \"Create security group\"\n",
+    "2. Provide a \"Security group name\" (e.g. `exobespin-sg`), and a description (e.g. \"Allow SSH for developers\").\n",
+    "3. Under \"VPC\", select the default VPC.\n",
+    "4. Under \"Inbound rules\", click \"Add rule\".  For \"Type\", select \"SSH\".  For \"Source\", select \"Anywhere\".\n",
+    "5. Under \"Outbound rules\", ensure that there in an outbound rule for \"All traffic\"\n",
+    "6. Click \"Create security group\"\n",
+    "\n",
+    "\n",
+    "With the security group created, users may now create the EC2 launch template:\n",
+    "\n",
+    "1. Navigate to the AWS EC2 console, click on \"Launch Templates\", and then select \"Create launch template\"\n",
+    "2. Provide a \"launch template name\" (e.g. `exobespin-lt`).  You may also optionally provide a description.\n",
+    "3. Under \"Amazon Machine Image\", choose an appropriate AMI (e.g. `Red Hat Enterprise Linux 8 (HVM), SSD Volume Type`)\n",
+    "4. Under \"Instance Type\", choose an appropriate instance type (e.g. `t2.small`)\n",
+    "5. Under \"Key Pain (login)\", choose an apporporate key pair\n",
+    "6. Under \"Network Settings\", choose \"Virtual Private Cloud (VPC)\".  Under \"Security groups\", choose the security group that was created above.\n",
+    "7. Under \"Storage\", click on \"Volume 1\" to expand the options.  Here, users may increase the size of the storage.\n",
+    "8. At the bottom of the page, click on \"Advanced details\" to expand the options. In the \"User data\" box, copy and paste the contents of the `build-exo_bespin-env-cpu.sh` file located in `exo_bespin.aws` subpackage.\n",
+    "9. Lastly, click \"Create launch template\".  The launch template will be created.  Users may now use the launch template ID in the `aws_config.json` file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A Simple Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Below is a \"Hello World\" type example of how to use the various functions of `exo_bespin.aws.aws_tools`*"
    ]
   },
   {
@@ -60,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*Please note that it will take a few seconds to start an existing EC2 instance, and take a few minutes to create a new EC2 instance and build the `exo-bespin` software environment.  Users are encourage to use python's `time.sleep()` in their specific software to make sure that the EC2 instance does not get invoked too soon.*"
+    "*Please note that it takes a **few seconds** to start an existing EC2 instance, and takes **several minutes** to create a new EC2 instance and build the `exo-bespin` software environment.  Users are encourage to use python's `time.sleep()` in their specific software to make sure that the EC2 instance does not get invoked too soon.*"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the `using_aws_ec2` notebook to include instructions on how to create an EC2 launch template for `exo_bespin`.